### PR TITLE
added config.json to .gitignore to prevent exposing private keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+config.json
+


### PR DESCRIPTION
self-explanatory. private bot token is stored in config.json, should not be shown online.