### PR TITLE
Allow red-team testing through manual context editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,70 +17,84 @@ Channels and channel administrator memberships are represented using Discord rol
 
 ```
 ?test
+?t
 ```
 Bot will provide its status. 'OK' means functional.
 
 ```
 ?state
+?s
 ```
 Display the state of the vote
 
 ```
 ?create-channel
+?c
 ```
 Create a channel with you as the only member and as the admin
 
 ```
 ?add-member [member] [channel]
+?a [member] [channel]
 ```
 Initiate a vote to add the specified member to the specified channel. You cannot record a yes/no vote using this command. (Requires 51% to occur)
 
 ```
 ?remove-member [member] [channel]
+?r [member] [channel]
 ```
 Initiate a vote to remove the specified member from the specified channel. You cannot record a yes/no vote using this command. (Requires 51% to occur)
 
 ```
 ?change-admin [member] [channel]
+?p [member] [channel]
 ```
 Initiate a vote to make the specified member admin of the specified channel. You cannot record a yes/no vote using this command. (Requires 51% to occur)
 
 ```
-?vote [yes/no]
+?vote [yes/no] <user>
+?v [yes/no] <user>
 ```
-Vote yes or no on the issue at hand. Prints a summary of the current vote counts.
+Vote yes or no on the issue at hand. Prints a summary of the current vote counts. If a user is provided, the system will respond as if that user cast that vote.
 
 ```
 ?change-user-context-add-member [member] [channel]
+?uca [member] [channel]
 ```
 Change your user context to add a user to your version of a channel
 
 ```
 ?change-user-context-remove-member [member] [channel]
+?ucr [member] [channel]
 ```
 Change your user context to remove a user from your version of a channel
 
 ```
 ?change-user-context-admin [member] [channel]
+?ucp [member] [channel]
 ```
 Change your user context to set a user as the admin of your version of a channel
 
 ```
 ?view-user-context [member] [channel]
+?ucv [member] [channel]
 ```
 View a given user's context for a given channel
 
 ```
 ?cancel-vote
+?cv
 ```
 Cancel the vote currently in progress
 
 ```
 ?reset
+?rs
 ```
 Resets all data
 
 ```
 ?sync-discord-roles [member] [channel]
+?d [member] [channel]
 ```
 Syncs the discord roles with a given user's context

--- a/src/context-manager.js
+++ b/src/context-manager.js
@@ -216,6 +216,16 @@ class ContextManagerClass {
 		return undefined
 	}
 
+	change_complete_user_context(user_uid, user_context) {
+		var contexts = this.get_all_contexts()
+		var userContext = contexts.find((context) => context.user === user_uid)
+		if(userContext !== undefined) {
+			userContext = undefined
+		}
+		contexts.push(user_context)
+		this.save_all_contexts()
+	}
+
 }
 
 const ContextManager = new ContextManagerClass()

--- a/src/endpoints.js
+++ b/src/endpoints.js
@@ -18,7 +18,8 @@ const commands = [ 	"(t) test",
 					"(ucr) change-user-context-remove-user [user] [role]",
 					"(ucv) view-user-context [user] [role]",
 					"(rs) reset",
-					"(d) sync-discord-roles [user] [role]"
+					"(d) sync-discord-roles [user] [role]",
+					"(u) upload-user-context [user] [context]"
 				]
 
 var voteInProgress = false;
@@ -245,6 +246,17 @@ function messageHandler(message) {
 			}
 			return message.reply("Error syncing roles")
 		})
+	}
+
+	else if (command === "upload-user-context" || command === "u") {
+		let member = message.mentions.members.first() || message.guild.members.get(args[0])
+		var raw_context_array = args
+		raw_context_array.shift()
+		var context_string = ""
+		raw_context_array.forEach((item) => context_string = context_string + item + " ")
+		var context = JSON.parse(context_string)
+		console.log(JSON.stringify(context, null, 2))
+		contextManager.change_complete_user_context(member.id, context)
 	}
 	
 	else {

--- a/src/endpoints.js
+++ b/src/endpoints.js
@@ -5,6 +5,20 @@ const contextManager = require("./context-manager");
 
 const positiveResponses = [ "yes", "y", "no'nt", "yea", "sure"]
 const negativeResponses = [ "no", "n", "yesn't", "nay"]
+const commands = [ 	"(t) test",
+					"(s) state",
+					"(a) add-member [user] [role]",
+					"(r) remove-member [user] [role]",
+					"(p) change-admin [user] [role]",
+					"(v) vote [yes/no] <user>",
+					"(c) create-channel [role]",
+					"(cv) cancel-vote",
+					"(ucp) change-user-context-admin [user] [role]",
+					"(uca) change-user-context-add-user [user] [role]",
+					"(ucr) change-user-context-remove-user [user] [role]",
+					"(ucv) view-user-context [user] [role]",
+					"(d) discord-sync"
+				]
 
 var voteInProgress = false;
 var state = null;
@@ -18,15 +32,15 @@ function messageHandler(message) {
 	const channel = message.channel.name
 	const author = message.author
 
-	if (command === "test") {
+	if (command === "test" || command === "t") {
 		return message.reply("Status: OK")
 	}
 
-	else if (command === "state") {
+	else if (command === "state" || command === "s") {
 		return message.reply(JSON.stringify(state, null, 2))
 	}
 
-	else if (command === "create-channel") {
+	else if (command === "create-channel" || command === "c") {
 		let role = message.guild.roles.find(role => role.name === args[0])
 		contextManager.add_channel(role.name, author.id)
 		tr.addUser(author, role)
@@ -34,7 +48,7 @@ function messageHandler(message) {
 		return message.reply("Created channel " + arg[0])
 	}
 
-	else if (command === "add-member") {
+	else if (command === "add-member" || command === "a") {
 		let member = message.mentions.members.first() || message.guild.members.get(args[0])
 		let role = message.guild.roles.find(role => role.name === args[1])
 		let channel = {
@@ -54,7 +68,7 @@ function messageHandler(message) {
 		return message.reply("Vote started to add member " + member.id)
 	}
 
-	else if (command === "remove-member") {
+	else if (command === "remove-member" || command === "r") {
 		let member = message.mentions.members.first() || message.guild.members.get(args[0])
 		let role = message.guild.roles.find(role => role.name === args[1])
 		let channel = {
@@ -74,7 +88,7 @@ function messageHandler(message) {
 		return message.reply("Vote started to remove member " + member.id)
 	}
 
-	else if (command === "change-admin") {
+	else if (command === "change-admin" || command === "p") {
 		let member = message.mentions.members.first() || message.guild.members.get(args[0])
 		let role = message.guild.roles.find(role => role.name === args[1])
 		let channel = {
@@ -94,7 +108,7 @@ function messageHandler(message) {
 		return message.reply("Vote started to promote member" + member.id)
 	}
 
-	else if (command === "vote") {
+	else if (command === "vote" || command === "v") {
 		let actor = author
 		let member = message.mentions.members.first()
 		if(member) {
@@ -157,7 +171,7 @@ function messageHandler(message) {
 		}
 	}
 
-	else if (command === "change-user-context-admin") {
+	else if (command === "change-user-context-admin"  || command === "ucp") {
 		let member = message.mentions.members.first() || message.guild.members.get(args[0])
 		let role = message.guild.roles.find(role => role.name === args[1])
 		if (!role) {
@@ -169,7 +183,7 @@ function messageHandler(message) {
 		return message.reply("Successfully changed admin to " + member.id)
 	}
 
-	else if (command === "change-user-context-add-member") {
+	else if (command === "change-user-context-add-member" || command === "uca") {
 		let member = message.mentions.members.first() || message.guild.members.get(args[0])
 		let role = message.guild.roles.find(role => role.name === args[1])
 		if (!role) {
@@ -183,7 +197,7 @@ function messageHandler(message) {
 		}		
 	}
 
-	else if (command === "change-user-context-remove-member") {
+	else if (command === "change-user-context-remove-member" || command === "ucr") {
 		let member = message.mentions.members.first() || message.guild.members.get(args[0])
 		let role = message.guild.roles.find(role => role.name === args[1])
 		if (!role) {
@@ -198,7 +212,7 @@ function messageHandler(message) {
 		}
 	}
 
-	else if (command === "view-user-context") {
+	else if (command === "view-user-context" || command === "ucv") {
 		let member = message.mentions.members.first() || message.guild.members.get(args[0])
 		let role = message.guild.roles.find(role => role.name === args[1])
 		if (!role) {
@@ -211,14 +225,17 @@ function messageHandler(message) {
 		return message.reply(JSON.stringify(currentUserContext, null, 2))
 	}
 	
-	else if (command === "cancel-vote") {
+	else if (command === "cancel-vote" || command === "cv") {
 		state = null;
 		voteInProgress = false;
 		return message.reply("Vote cancelled.")
 	}
 	
 	else {
-		return message.reply("Available commands: \n\
+		var helpString = "Available commands:\n"
+		commands.forEach((singleCmd) => helpString = helpString + singleCmd + "\n")
+		return message.reply(helpString)
+		/*return message.reply("Available commands: \n\
 		test \n\
 		state \n\
 		add-member [user] [role]\n\
@@ -230,7 +247,7 @@ function messageHandler(message) {
 		change-user-context-add-user [user] [role]\n\
 		change-user-context-remove-user [user] [role]\n\
 		view-user-context [user] [role]\n"
-		)
+		)*/
 	}
 }
 


### PR DESCRIPTION
Adds an endpoint to allow developers to manually edit any user's context to set it to whatever text they input. Adds a function in context manager to allow this as well.